### PR TITLE
tweaks to pom required for a clean install

### DIFF
--- a/loads/pom.xml
+++ b/loads/pom.xml
@@ -58,7 +58,10 @@
         <dependency>
             <groupId>org.mousephenotype.dcc.exportlibrary.xmlserialization</groupId>
             <artifactId>exportlibrary.xmlserialization</artifactId>
-            <version>1.3.1</version>
+            <!-- current version of exportlibrary defines v1.3.1 
+            <version>1.3.1</version> 
+            -->
+            <version>1.3.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
@@ -98,8 +101,10 @@
             <artifactId>jopt-simple</artifactId>
         </dependency>
 
-		<!-- MGI intermine project -->
-	    <dependency>
+	<!-- MGI intermine project -->
+        <!-- Removed intermine dependencies 
+	    
+        <dependency>
             <groupId>org.intermine</groupId>
             <artifactId>metadata</artifactId>
             <version>1.0.0</version>
@@ -116,6 +121,8 @@
             <artifactId>webservice</artifactId>
             <version>1.0.0</version>
         </dependency>
+        
+        -->
 
         <!-- Jersey web services client dependencies -->
         <dependency>


### PR DESCRIPTION
These are two pom tweaks that I had to apply to perform a from-scratch build

one change of version in an exportlibrary dependency
(current version on github defines 1.3.3, pom asked for 1.3.1)

comment out of intermine dependencies
(intermine does not appear in the rest of the module)