### PR TITLE
Update documentation for FTP data release folder

### DIFF
--- a/reports/src/main/resources/currentDataRelease/README.md
+++ b/reports/src/main/resources/currentDataRelease/README.md
@@ -13,11 +13,15 @@ of the current data for every new data release._
 - cores - This directory contains a unix tar `.tar` file
   for each core.
 
-- impc_bulk_api – This directory contains JSON-formatted datasets prepared for bulk access via the IMPC API.
+- impc_bulk_api – This directory contains JSON-formatted
+datasets prepared for bulk access via the IMPC API.
 
-- impc_kg – This directory contains JSON files representing entities and relationships used to construct the IMPC Knowledge Graph.
+- impc_kg – This directory contains JSON files 
+representing entities and relationships used to construct 
+the IMPC Knowledge Graph.
 
-- input – This directory contains several gzipped (.tar.gz) archives used as inputs for the IMPC data processing.
+- input – This directory contains several gzipped (.tar.gz) 
+archives used as inputs for the IMPC data processing.
 
 - mongo - This directory contains a gzipped `.gz` file
   containing a MongoDB dump of the IMPC database, created

--- a/reports/src/main/resources/currentDataRelease/README.md
+++ b/reports/src/main/resources/currentDataRelease/README.md
@@ -1,30 +1,24 @@
 # Description
-This directory contains data release information for
-data release DATA_RELEASE_NUMBER. Included are: 
-all the genotype to phenotype associations using the
-Mammalian Phenotype (MP) ontology calculated from
-the statistical analysis (using the PhenStat R 
-package), as well as general-use and purpose-built
-reports for each data release. _NOTE: these
-results are created from a snapshot of the current
-data for every new data release._
+This directory contains data release information 
+for the IMPC data release DATA_RELEASE_NUMBER. Included are: 
+all the genotype to phenotype associations 
+using the Mammalian Phenotype (MP) ontology 
+calculated from the statistical analysis
+with OpenStats R package, as well as general-use 
+and purpose-built reports for each data release. 
+_NOTE: these results are created from a snapshot 
+of the current data for every new data release._
 
-## Subdirectories
-- cores   - This directory contains a unix tar `.tar` file
+# Subdirectories
+- cores - This directory contains a unix tar `.tar` file
   for each core.
 
-- mysql   - This directory contains a gzipped `.gz` file
-  containing a mysqldump of the IMPC database, created
-  at release time. _NOTE: beginning with data release 12.0,
-  the database is significantly smaller._
+- mongo - This directory contains a gzipped `.gz` file
+  containing a MongoDB dump of the IMPC database, created
+  at release time.
 
 - results - This directory contains a set of gzipped `.gz`
   report files containing statistically processed IMPC data,
   generated at release time. As of data release 12.0, this
   directory is a combination of the prior `csv` and `reports`
   directories.
-- docker  - For the past several releases, we have included a
-  ready-to-run docker image  of the IMPC web portal and API.
-  However, due to the large size of the cores, which are a
-  part of the docker image, the docker file may not be created
-  or available.

--- a/reports/src/main/resources/currentDataRelease/README.md
+++ b/reports/src/main/resources/currentDataRelease/README.md
@@ -13,6 +13,12 @@ of the current data for every new data release._
 - cores - This directory contains a unix tar `.tar` file
   for each core.
 
+- impc_bulk_api – This directory contains JSON-formatted datasets prepared for bulk access via the IMPC API.
+
+- impc_kg – This directory contains JSON files representing entities and relationships used to construct the IMPC Knowledge Graph.
+
+- input – This directory contains several gzipped (.tar.gz) archives used as inputs for the IMPC data processing.
+
 - mongo - This directory contains a gzipped `.gz` file
   containing a MongoDB dump of the IMPC database, created
   at release time.


### PR DESCRIPTION
- [x] Update description 
- [x] Removed outdated folders from the description: `mysql` and `docker`
- [x] Created description for `impc_bulk_api`, `impc_kg`, `input` and `mongo`